### PR TITLE
Add Steam Deck built-in controller support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project is a fork of [Pila's SteamControllerSinger](https://gitlab.com/Pilatomic/SteamControllerSinger) including a dirty fix to make the Steam Controller sing again.
 
+The Steam Deck is also supported, since its built-in controller is very similar to the Steam Controller!
+
 **Note: Steam Controller Singer currently only works on GNU/Linux, and this fork was created to address a GNU/Linux-only issue. Therefore, no Microsoft Windows executable is provided (if you want one, go to the original source), and no Microsoft Windows related issues will be accepted.**
 
 ## HOW TO
@@ -68,3 +70,5 @@ Midi files may need to be edited with a software such [MidiEditor](https://www.m
 ## Compiling
 
 You will need libusb(-dev) and pkgconf. If you have them, just type `make`.
+
+On the Steam Deck, you'll also need the base-devel, gcc, and linux-api-headers packages, in addition to libusb. You can install these with pacman after running `sudo steamos-readonly disable`.

--- a/main.cpp
+++ b/main.cpp
@@ -55,6 +55,11 @@ bool SteamController_Open(SteamControllerInfos* controller){
         controller->dev_handle = dev_handle;
         controller->interfaceNum = 1;
     }
+    else if ((dev_handle = libusb_open_device_with_vid_pid(NULL, 0x28DE, 0x1205)) != NULL){ // Steam Deck
+	cout<<"Found Steam Deck built-in controller"<<endl;
+	controller->dev_handle = dev_handle;
+	controller->interfaceNum = 2;
+    }
     else{
         cout<<"No device found"<<endl;
         return false;

--- a/main.cpp
+++ b/main.cpp
@@ -56,9 +56,9 @@ bool SteamController_Open(SteamControllerInfos* controller){
         controller->interfaceNum = 1;
     }
     else if ((dev_handle = libusb_open_device_with_vid_pid(NULL, 0x28DE, 0x1205)) != NULL){ // Steam Deck
-	cout<<"Found Steam Deck built-in controller"<<endl;
-	controller->dev_handle = dev_handle;
-	controller->interfaceNum = 2;
+        cout<<"Found Steam Deck built-in controller"<<endl;
+        controller->dev_handle = dev_handle;
+        controller->interfaceNum = 2;
     }
     else{
         cout<<"No device found"<<endl;


### PR DESCRIPTION
This PR adds support for the Steam Deck's built-in controller.

It seems to be as simple as adding the correct VID and PID.

Video showing it in action: https://www.youtube.com/watch?v=KCYmJfSWhtw